### PR TITLE
Tag ABI version as well

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,8 @@ jobs:
             git submodule sync
             git submodule update --init
 
-      - setup_docker_engine
+      - setup_remote_docker:
+          version: 17.07.0-ce-git
 
       - run:
           name: build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             git submodule update --init
 
       - setup_remote_docker:
-          version: 17.07.0-ce-git
+          version: 17.07.0-ce
 
       - run:
           name: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM ubuntu
+ARG BOILERPLATE_PARENT_IMAGE="ubuntu"
+ARG BOILERPLATE_PARENT_TAG="latest"
+FROM $BOILERPLATE_PARENT_IMAGE:$BOILERPLATE_PARENT_TAG
+
 MAINTAINER Trevor Joynson "<docker@trevor.joynson.io>"
 
 ENV DEBIAN_FRONTEND=noninteractive \
@@ -24,6 +27,8 @@ ENV LANGUAGE=$LANG \
 ENV PATH=$APP_PATH:$IMAGE_PATH:$PATH:$BUSYBOX_PATH
 
 WORKDIR $IMAGE_ROOT
+
+ARG BOILERPLATE_ABI="latest"
 
 RUN set -exv \
  && echo "Installing common packages" \

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,10 @@
+BOILERPLATE_ABI := 2017.9
+
+TAG_PARTS ?= $(subst -, ,$@)
+BUILD_ARGS ?= --build-arg BOILERPLATE_ABI=$(BOILERPLATE_ABI) \
+			  --build-arg BOILERPLATE_PARENT_TAG=$(firstword $(TAG_PARTS))
+
+EXTRA_TAGS += $(foreach TAG,$(UBUNTU_TAGS),$(TAG)-$(BOILERPLATE_ABI)=$(TAG))
+
 include Makefile.docker
 

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -37,9 +37,9 @@ ${RUN_CMDS}: CMD = bash
 ${RUN_CMDS}: run
 
 export ENTRYPOINT_DEBUG ENTRYPOINT_VERBOSE ENTRYPOINT_TRACE
-bash-debug: 	ENTRYPOINT_DEBUG=1
-bash-verbose: ENTRYPOINT_VERBOSE=1
-bash-trace: 	ENTRYPOINT_TRACE=1
+bash-debug:		ENTRYPOINT_DEBUG=1
+bash-verbose:	ENTRYPOINT_VERBOSE=1
+bash-trace:		ENTRYPOINT_TRACE=1
 
 RUN_CMD ?= docker run -it --rm -v ${PWD}:/app
 
@@ -68,18 +68,14 @@ distclean: clean
 deps: ${DEPS}
 
 BUILD_ARGS ?=
-BUILD_FROM_TAG ?= $@
 
 $(TAGS): Dockerfile deps
-	-echo -- $@: REPO=${REPO} TAG=${TAG} BUILD_TAG=${BUILD_TAG_PREFIX}$@ BUILD_FROM_TAG=${BUILD_FROM_TAG} >&2
-	sed -e 's/^\(FROM .*\)\(:.*\|\)$$/\1:${BUILD_FROM_TAG}/' '$<' > '$<.$@.tmp' \
-		&& mv '$<.$@.tmp' '$<.$@'
-	sleep 1; \
-		docker build \
-		${BUILD_ARGS} \
-		-f "$<.$@" \
-		-t "${REPO}:${BUILD_TAG_PREFIX}$@" \
-		.
+	-echo -- $@: REPO=${REPO} TAG=${TAG} BUILD_TAG=${BUILD_TAG_PREFIX}$@ >&2
+	./image/bin/prefixout -dtc --prefix "[$@] " -- \
+	  docker build \
+	  ${BUILD_ARGS} \
+	  -t "${REPO}:${BUILD_TAG_PREFIX}$@" \
+	  .
 
 build: $(TAGS)
 	@echo "-- $@: TAGS=${TAGS}" >&2


### PR DESCRIPTION
This also swaps to using `ARG`s in the `FROM`, simplifying it a bit. This is possible now with Docker 17.07-ce, possibly 17.06-ce as well but unsure.